### PR TITLE
chore: import repository https://github.com/cloudtraktor/x-common-io.git

### DIFF
--- a/.jx/gitops/source-config.yaml
+++ b/.jx/gitops/source-config.yaml
@@ -10,6 +10,12 @@ spec:
     repositories:
     - name: x-common-io
     scheduler: in-repo
+  - owner: cloudtraktor
+    provider: https://github.com
+    providerKind: github
+    repositories:
+    - name: x-common-io
+    scheduler: in-repo
   slack:
     channel: '#jenkins-x-pipelines'
     kind: failureOrNextSuccess


### PR DESCRIPTION
this commit will trigger a pipeline to [generate the CI/CD configuration](https://jenkins-x.io/v3/about/how-it-works/#importing--creating-quickstarts) which will create a second commit on this Pull Request before it auto merges
